### PR TITLE
[fix] 初期状態でTenssy4.1単体をコンパイルするとサーボが回りまくってしまうので修正

### DIFF
--- a/teensy/src/servo_maneuver.cpp
+++ b/teensy/src/servo_maneuver.cpp
@@ -8,6 +8,8 @@ ServoManeuver::ServoManeuver(int left_servo_pin, int right_servo_pin)
 void ServoManeuver::init() {
     left_servo_.init();
     right_servo_.init();
+    delay(10);
+    stop();
 }
 
 void ServoManeuver::moveForward() {


### PR DESCRIPTION
## Related issues
N/A

## Description
初期状態でTenssy4.1単体をコンパイルするとサーボが回りまくってしまうので修正

## Test results
実機で検証済
